### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,8 +31,9 @@ class ItemsController < ApplicationController
   def destroy
     if @item.user == current_user
       @item.destroy
-      redirect_to root_path
+    else
     end
+    redirect_to root_path
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -24,6 +24,13 @@ class ItemsController < ApplicationController
 
   def edit
     if @item.user != current_user
+      redirect_to root_path
+    end
+  end
+
+  def destroy
+    if @item.user == current_user
+      @item.destroy
       redirect_to root_path
     end
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", item_path, data: {turbo_method: :delete}, class:"item-destroy" %>
     <% elsif user_signed_in? && current_user.id != @item.user_id%>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% elsif @order.blank?%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items,only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
どのような実装をしているのか
## 商品削除機能
* items/destroyアクションの生成
  * ルーティングのresourcesのonlyオプションを削除しました。
  * コントローラにdestroyアクションを追加しました。
  * 詳細ページの削除ボタンを編集しました。

* コントローラに条件分岐を追加
  * authenticate_user!にdestroyを追記しました。
  * destroyアクションに条件分岐を指定しました。


# Why
なぜこの実装が必要なのか
* 出品したユーザーのみ、その商品を削除できる権限を与えます。
  * ログアウト状態では削除出来ないよう制限しました。
  * 出品ユーザーとログインユーザーが異なる状態では削除出来ないよう制限しました。

## 参考動画
[ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画](https://gyazo.com/4635d0ec8cb242630fc9f4a45ec4b500)